### PR TITLE
Add Recipient and Message resource types

### DIFF
--- a/front/models.py
+++ b/front/models.py
@@ -219,11 +219,13 @@ class Channel(Resource, mixins.Readable, mixins.Creatable):
 
     inbox = Related('front.Inbox', sub=True)
 
+
 class Recipient(Schema):
 
     contact = Related(Contact)
     handle = fields.Str()
     role = fields.Str()
+
 
 class Message(Resource, mixins.Readable):
     class Meta:
@@ -242,7 +244,7 @@ class Message(Resource, mixins.Readable):
     is_inbound = fields.Boolean()
     recipients = fields.Nested(Recipient, many=True)
     text = fields.Str()
-    
+
 
 class Conversation(Resource, mixins.Readable):
     class Meta:

--- a/front/models.py
+++ b/front/models.py
@@ -219,6 +219,30 @@ class Channel(Resource, mixins.Readable, mixins.Creatable):
 
     inbox = Related('front.Inbox', sub=True)
 
+class Recipient(Schema):
+
+    contact = Related(Contact)
+    handle = fields.Str()
+    role = fields.Str()
+
+class Message(Resource, mixins.Readable):
+    class Meta:
+        list_path = 'messages/'
+        detail_path = 'messages/{id}/'
+
+    objects = Manager()
+
+    type = fields.Str()
+    author = fields.Str()
+    blurb = fields.Str()
+    body = fields.Str()
+    created_at = fields.DateTime()
+    id = fields.Str()
+    is_draft = fields.Boolean()
+    is_inbound = fields.Boolean()
+    recipients = fields.Nested(Recipient, many=True)
+    text = fields.Str()
+    
 
 class Conversation(Resource, mixins.Readable):
     class Meta:
@@ -227,13 +251,14 @@ class Conversation(Resource, mixins.Readable):
 
     objects = Manager()
 
+    messages = Related(Message, many=True, sub=True)
     id = fields.Str()
     subject = fields.Str()
     status = fields.Str()
     assignee = fields.Nested('TeammateSchema', allow_none=True)
-    recipient = fields.Nested('ContactSchema')
+    recipient = fields.Nested(Recipient)
     tags = fields.Nested('TagSchema', many=True)
-    # last_message = None  # todo
+    last_message = fields.Nested('MessageSchema')
     created_at = UnixEpochDateTime()
 
 


### PR DESCRIPTION
Adds a Schema for the Message type.
Adds a Schema for the Recipient type, which is used by Message.

Updates schema for Conversation to use Recipient schema for the Recipient field, as the recipient is not a contact. Fixes #11 